### PR TITLE
Skip files without Pastoria decorators via regex check

### DIFF
--- a/packages/pastoria/src/generate.ts
+++ b/packages/pastoria/src/generate.ts
@@ -81,6 +81,9 @@ type AppRoot = {
   symbol: Symbol;
 };
 
+// Regex to quickly check if a file contains any Pastoria JSDoc tags
+const PASTORIA_TAG_REGEX = /@(route|resource|appRoot|param)\b/;
+
 function collectRouterNodes(project: Project): {
   resources: RouterResource[];
   routes: RouterRoute[];
@@ -91,7 +94,12 @@ function collectRouterNodes(project: Project): {
   let appRoot: AppRoot | null = null;
 
   function visitRouterNodes(sourceFile: SourceFile) {
-    // TODO: Skip sourceFile if a pastora JSDoc tag isn't used at all.
+    // Skip files that don't contain any Pastoria JSDoc tags
+    const fileText = sourceFile.getFullText();
+    if (!PASTORIA_TAG_REGEX.test(fileText)) {
+      return;
+    }
+
     sourceFile.getExportSymbols().forEach((symbol) => {
       let routerResource = null as RouterResource | null;
       let routerRoute = null as RouterRoute | null;


### PR DESCRIPTION
## Summary

Optimize code generation performance by using a regex to quickly filter out files that don't contain any Pastoria JSDoc tags before doing expensive AST traversal and symbol processing.

## Changes

- Added `PASTORIA_TAG_REGEX` pattern that matches `@route`, `@resource`, `@appRoot`, and `@param` tags
- Early return in `visitRouterNodes()` if the file text doesn't match the pattern
- Removed the TODO comment about this optimization

## Performance Impact

This optimization provides significant benefits in large codebases:
- Skips AST traversal for files without Pastoria decorators
- Avoids calling `getExportSymbols()` and `getDeclarations()` unnecessarily
- Regex check is very fast compared to full symbol processing

## Example

Files like:
- `utils/helpers.ts`
- `components/Button.tsx` 
- `lib/constants.ts`

Will now be skipped entirely during code generation since they don't contain any Pastoria JSDoc tags.

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)