### PR TITLE
Enable React Compiler for all Pastoria projects

### DIFF
--- a/packages/pastoria/package.json
+++ b/packages/pastoria/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.1.14",
     "@vitejs/plugin-react": "^5.0.4",
+    "babel-plugin-react-compiler": "^1.0.0",
     "commander": "catalog:",
     "cookie-parser": "catalog:",
     "dotenv": "catalog:",

--- a/packages/pastoria/src/build.ts
+++ b/packages/pastoria/src/build.ts
@@ -137,7 +137,14 @@ export function createBuildConfig(
     plugins: [
       pastoriaEntryPlugin(),
       tailwindcss(),
-      react({babel: {plugins: ['relay']}}),
+      react({
+        babel: {
+          plugins: [
+            ['babel-plugin-react-compiler', {}],
+            'relay',
+          ],
+        },
+      }),
       cjsInterop({
         dependencies: ['react-relay', 'react-relay/hooks', 'relay-runtime'],
       }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,10 +16,10 @@ catalogs:
       specifier: ^22.12.0
       version: 22.18.8
     '@types/react':
-      specifier: ^19.1.2
+      specifier: ^19.2.0
       version: 19.2.1
     '@types/react-dom':
-      specifier: ^19.1.3
+      specifier: ^19.2.0
       version: 19.2.0
     '@types/react-relay':
       specifier: ^18.2.1
@@ -46,10 +46,10 @@ catalogs:
       specifier: ^1.1.1
       version: 1.1.1
     react:
-      specifier: ^19.1.0
+      specifier: ^19.2.0
       version: 19.2.0
     react-dom:
-      specifier: ^19.1.0
+      specifier: ^19.2.0
       version: 19.2.0
     react-relay:
       specifier: ^20.1.1
@@ -88,6 +88,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^5.0.4
         version: 5.0.4(vite@7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0))
+      babel-plugin-react-compiler:
+        specifier: ^1.0.0
+        version: 1.0.0
       commander:
         specifier: 'catalog:'
         version: 14.0.1
@@ -2711,6 +2714,9 @@ packages:
     resolution: {integrity: sha512-ISqQ2frbiNU9vIJkzg7dlPpznPZ4jOiUQ1uSmB0fEHeowtN3COYRsXr/xexn64NpU13P06jc/L5TgiJXOgrbEg==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+
+  babel-plugin-react-compiler@1.0.0:
+    resolution: {integrity: sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==}
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
@@ -9776,6 +9782,10 @@ snapshots:
       '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.4)
     transitivePeerDependencies:
       - supports-color
+
+  babel-plugin-react-compiler@1.0.0:
+    dependencies:
+      '@babel/types': 7.28.4
 
   bail@2.0.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,8 +6,8 @@ catalog:
   '@types/cookie-parser': ^1.4.9
   '@types/express': ^5.0.3
   '@types/node': ^22.12.0
-  '@types/react': ^19.1.2
-  '@types/react-dom': ^19.1.3
+  '@types/react': ^19.2.0
+  '@types/react-dom': ^19.2.0
   '@types/react-relay': ^18.2.1
   '@types/relay-runtime': ^19.0.2
   commander: ^14.0.1
@@ -16,8 +16,8 @@ catalog:
   express: ^5.1.0
   graphql: ^16.8.1
   picocolors: ^1.1.1
-  react: ^19.1.0
-  react-dom: ^19.1.0
+  react: ^19.2.0
+  react-dom: ^19.2.0
   react-relay: ^20.1.1
   relay-runtime: ^20.1.1
   typescript: ^5.9.2


### PR DESCRIPTION
## Summary

This PR enables the React Compiler for all Pastoria projects, providing automatic React optimization without requiring manual memoization.

## What is React Compiler?

The React Compiler is a stable compiler from the React team that automatically optimizes React components by analyzing code and minimizing unnecessary re-renders. It reduces or eliminates the need for manual memoization with `useMemo`, `useCallback`, and `memo`.

## Changes

- **React Upgrade**: Updated React and React DOM to 19.2.0 (minimum version for stable compiler)
- **Dependencies**: Added `babel-plugin-react-compiler@1.0.0` (stable release) to the pastoria package
- **Build Configuration**: Configured React Compiler in the Babel plugin pipeline
  - Runs **before** the Relay plugin to access original source code
  - Automatically enabled for all user projects (no opt-in required)

## Configuration

```javascript
react({
  babel: {
    plugins: [
      ['babel-plugin-react-compiler', {}],  // Runs first
      'relay',
    ],
  },
})
```

## Benefits for Users

- ✅ Automatic optimization of React components
- ✅ Fewer manual `useMemo`/`useCallback` needed
- ✅ Better performance out of the box
- ✅ Zero configuration required
- ✅ Works seamlessly with Relay
- ✅ Using stable 1.0.0 release with React 19.2

## Testing

All packages build successfully with React 19.2 and the stable React Compiler enabled.

Fixes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)