### PR TITLE
Fix query parameter collection from nested resources

### DIFF
--- a/packages/pastoria/src/generate.ts
+++ b/packages/pastoria/src/generate.ts
@@ -502,10 +502,17 @@ async function generateRouter(project: Project, metadata: PastoriaMetadata) {
         },
       });
 
-      if (params.size === 0 && consumedQueries.size > 0) {
-        console.log(routeName, consumedQueries);
-        // TODO(#42): Implement query parameter collection from nested entrypoints.
-        params = collectQueryParameters(project, Array.from(consumedQueries));
+      if (consumedQueries.size > 0) {
+        const queryParams = collectQueryParameters(
+          project,
+          Array.from(consumedQueries),
+        );
+        // Merge query parameters from nested entrypoints without overriding existing params
+        for (const [key, value] of queryParams) {
+          if (!params.has(key)) {
+            params.set(key, value);
+          }
+        }
       }
 
       for (const query of consumedQueries) {


### PR DESCRIPTION
Resolves #42 by always collecting query parameters from consumed queries
(including nested entrypoints/resources) and merging them with any
existing route parameters.

Previously, query parameters from nested resources were only collected
when the route had no @param tags. Now parameters are collected from all
consumed queries and merged without overriding existing params.